### PR TITLE
Added SeManageVolumePrivilege to HighPotentialPrivileges

### DIFF
--- a/PrivescCheck.ps1
+++ b/PrivescCheck.ps1
@@ -4140,7 +4140,7 @@ function Invoke-UserPrivilegesCheck {
 
     [CmdletBinding()] param()    
 
-    $HighPotentialPrivileges = "SeAssignPrimaryTokenPrivilege", "SeImpersonatePrivilege", "SeCreateTokenPrivilege", "SeDebugPrivilege", "SeLoadDriverPrivilege", "SeRestorePrivilege", "SeTakeOwnershipPrivilege", "SeTcbPrivilege", "SeBackupPrivilege"
+    $HighPotentialPrivileges = "SeAssignPrimaryTokenPrivilege", "SeImpersonatePrivilege", "SeCreateTokenPrivilege", "SeDebugPrivilege", "SeLoadDriverPrivilege", "SeRestorePrivilege", "SeTakeOwnershipPrivilege", "SeTcbPrivilege", "SeBackupPrivilege", "SeManageVolumePrivilege"
 
     $CurrentPrivileges = Get-UserPrivileges
 


### PR DESCRIPTION
SeManageVolumePrivilege to "Full Admin" escalation:
1. Enable the privilege in the token
2. Create handle to \\.\C: with SYNCHRONIZE | FILE_TRAVERSE
3. Send the FSCTL_SD_GLOBAL_CHANGE to replace S-1-5-32-544 with S-1-5-32-545
4. Overwrite utilman.exe etc.
from https://twitter.com/0gtweet/status/1303427935647531018

PoC that I tested can be found here:
https://github.com/gtworek/PSBits/blob/master/Misc/FSCTL_SD_GLOBAL_CHANGE.c
Note: You'd probably want to investigate a more elegant and reversible method if used in prod, but it works regardless.