### PR TITLE
Wrong ScriptPath variable for in memory execution

### DIFF
--- a/PrivescCheck.ps1
+++ b/PrivescCheck.ps1
@@ -6581,6 +6581,12 @@ function Invoke-PrivescCheck {
         [void] $AllChecks.Add($_)
     }
 
+    # Test for in memory execution or decoding at runtime
+    if (!(Test-path $ScriptPath))
+    {
+        $ScriptPath = (Get-Item -Path ".\" -Verbose).FullName
+    }
+
     # Load plugins if any
     Write-Verbose "Script path: $($ScriptPath)"
     $ScriptLocation = Split-Path -Parent $ScriptPath -ErrorAction SilentlyContinue -ErrorVariable ErrorSplitPath
@@ -6596,6 +6602,7 @@ function Invoke-PrivescCheck {
             Write-Verbose "No plugin definition file found."
         }
     }
+
     
     # Load plugin scripts if any
     $AllChecks | Where-Object { $_.File -ne "" } | Select-Object -ExpandProperty File | Sort-Object -Unique | ForEach-Object {
@@ -6703,7 +6710,6 @@ function Invoke-Check {
     $Result = Invoke-Expression -Command "$($Check.Command) $($Check.Params)"
     $Check | Add-Member -MemberType "NoteProperty" -Name "ResultRaw" -Value $Result
     $Check | Add-Member -MemberType "NoteProperty" -Name "ResultRawString" -Value $($Result | Format-List | Out-String)
-
     if ($($Check.Type -Like "vuln")) {
         if ($Result) {
             $Check | Add-Member -MemberType "NoteProperty" -Name "Compliance" -Value "KO"
@@ -6713,11 +6719,9 @@ function Invoke-Check {
         }
     } else {
         $Check | Add-Member -MemberType "NoteProperty" -Name "Compliance" -Value "N/A"
-        if (-not $Result) {
-            $Check.Severity = "None"
-        }
     }
     [void] $ResultArrayList.Add($Check)
+    # $Check.ResultRaw
     $Check
 }
 

--- a/PrivescCheck.ps1
+++ b/PrivescCheck.ps1
@@ -6589,7 +6589,14 @@ function Invoke-PrivescCheck {
 
     # Load plugins if any
     Write-Verbose "Script path: $($ScriptPath)"
-    $ScriptLocation = Split-Path -Parent $ScriptPath -ErrorAction SilentlyContinue -ErrorVariable ErrorSplitPath
+    if ($ScriptPath -imatch ".ps1")
+    {
+        $ScriptLocation = Split-Path -Parent $ScriptPath -ErrorAction SilentlyContinue -ErrorVariable ErrorSplitPath
+    }
+    else
+    {
+        $ScriptLocation = $ScriptPath
+    }
     if (-not $ErrorSplitPath) {
         $PrivescCheckPluginsCsvPath = Join-Path $ScriptLocation -ChildPath "\PrivescCheckPlugins\PrivescCheckPlugins.csv"
         Write-Verbose "Plugin definition file: '$($PrivescCheckPluginsCsvPath)'"

--- a/PrivescCheck.ps1
+++ b/PrivescCheck.ps1
@@ -6726,9 +6726,12 @@ function Invoke-Check {
         }
     } else {
         $Check | Add-Member -MemberType "NoteProperty" -Name "Compliance" -Value "N/A"
+        if (-not $Result) {
+            $Check.Severity = "None"
+        }
     }
     [void] $ResultArrayList.Add($Check)
-    # $Check.ResultRaw
+    
     $Check
 }
 


### PR DESCRIPTION
Hi,

first of all you really did some nice work on this in the last months. Thank you for that, this is my favorite Privesc-Script atm.

I found that by loading your script not from disk but from a webserver or decoding it at runtime the global `$ScriptPath` variable is -  wrong. For example:
`
IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/itm4n/PrivescCheck/master/PrivescCheck.ps1')
`
`
Invoke-PrivescCheck -Extended -Report PrivescCheck2 -Format CSV,HTML,txt -Verbose 
`
Results in a `$ScriptPath` variable with the content of the last command which is `IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/itm4n/PrivescCheck/master/PrivescCheck.ps1')` in this case.

So the Plugin-Loading results in some error messages:

![grafik](https://user-images.githubusercontent.com/27858067/97578764-8ab71880-19f1-11eb-95bd-ac1dd8676ca4.png)

My changes just check for a correct path set the Current Working directory as `$ScriptPath` if its not found.

![grafik](https://user-images.githubusercontent.com/27858067/97582552-2fd3f000-19f6-11eb-97b2-95c5f4dc1a7e.png)

Greetings