### PR TITLE
Get-ScheduledTaskList: Remove member enumeration in favor of `Select-Object -ExpandProperty` (fixes #8)

### DIFF
--- a/PrivescCheck.ps1
+++ b/PrivescCheck.ps1
@@ -2493,22 +2493,22 @@ function Get-ScheduledTaskList {
     
                     [xml]$TaskXml = $_.Xml
                     $TaskExec = $TaskXml.GetElementsByTagName("Exec")
-                    $TaskCommandLine = "$($TaskExec.Command) $($TaskExec.Arguments)"
+                    $TaskCommandLine = "$($TaskExec | Select-Object -ExpandProperty Command) $($TaskExec | Select-Object -ExpandProperty Arguments -ErrorAction SilentlyContinue)"
                     $Principal = $TaskXml.GetElementsByTagName("Principal")
                     
                     $CurrentUserIsOwner = $False
     
-                    if ($Principal.UserId) {
-                        $PrincipalName = Convert-SidToName -Sid $Principal.UserId
+                    if ($Principal | Select-Object -ExpandProperty UserId) {
+                        $PrincipalName = Convert-SidToName -Sid ($Principal | Select-Object -ExpandProperty UserId)
                         
-                        if ($(Invoke-UserCheck).SID -eq $Principal.UserId) {
+                        if ($(Invoke-UserCheck).SID -eq ($Principal | Select-Object -ExpandProperty UserId)) {
                             $CurrentUserIsOwner = $True
                         }
-                    } elseif ($Principal.GroupId) {
-                        $PrincipalName = Convert-SidToName -Sid $Principal.GroupId
+                    } elseif ($Principal | Select-Object -ExpandProperty GroupId) {
+                        $PrincipalName = Convert-SidToName -Sid ($Principal | Select-Object -ExpandProperty GroupId)
                     }
     
-                    if ($TaskExec.Command.Length -gt 0) {
+                    if (($TaskExec | Select-Object -ExpandProperty Command).Length -gt 0) {
     
                         $ResultItem = New-Object -TypeName PSObject 
                         $ResultItem | Add-Member -MemberType "NoteProperty" -Name "TaskName" -Value $TaskName


### PR DESCRIPTION
I tried to fix issue #8, by replacing instances of member enumeration by `Select-Object -ExpandProperty` in the function `Get-ScheduledTaskList`. This makes `Get-ScheduledTaskList` compatible with Powershell V2, as member enumeration was only introduced in PS V3.

Cheers!