### PR TITLE
Get-ServiceManagerDacl: handle NULL DACL case

### DIFF
--- a/PrivescCheck.ps1
+++ b/PrivescCheck.ps1
@@ -1257,8 +1257,19 @@ function Get-ServiceManagerDacl {
 
                 $RawSecurityDescriptor = New-Object Security.AccessControl.RawSecurityDescriptor -ArgumentList $BinarySecurityDescriptor, 0
                 
-                $Dacl = $RawSecurityDescriptor.DiscretionaryAcl | ForEach-Object {
-                    Add-Member -InputObject $_ -MemberType NoteProperty -Name AccessRights -Value $([PrivescCheck.Win32+ServiceManagerAccessFlags] $_.AccessMask) -PassThru
+                $Dacl = $RawSecurityDescriptor.DiscretionaryAcl
+                if ($Dacl -eq $null) { # NULL DACL = all access to everyone
+                    $Dacl = New-Object -TypeName PSObject -Property (@{
+                        AceType = "AccessAllowed";
+                        SecurityIdentifier = "S-1-1-0";
+                        AccessMask = [PrivescCheck.Win32+ServiceManagerAccessFlags]::AllAccess;
+                        AccessRights = "AllAccess"
+                    })
+                }
+                else {
+                    $Dacl | ForEach-Object {
+                        Add-Member -InputObject $_ -MemberType NoteProperty -Name AccessRights -Value $([PrivescCheck.Win32+ServiceManagerAccessFlags] $_.AccessMask) -PassThru
+                    }
                 }
 
                 $Dacl


### PR DESCRIPTION
As [discussed on Twitter](https://twitter.com/cnotin/status/1380275906359537664) NULL DACL is a very rare case which gives all access to everyone!
I confirmed it by being able to remotely `sc \\dc.lab.lan query` with an unprivileged user (which wasn't possible before).

Here's how to create this case:
```
sc.exe sdset scmanager "D:NO_ACCESS_CONTROL"
```

And this is what it returns:
```
PS > Invoke-SCMPermissionsCheck

AceType           AccessRights       IdentitySid     IdentityName                                            
-------           ------------       -----------     ------------                                            
AccessAllowed     AllAccess          S-1-1-0         Everyone   
```