### PR TITLE
Add option to hide some items in HTML report

### DIFF
--- a/info/CHANGELOG.md
+++ b/info/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-03-04
+
+### Added
+
+- Make table in HTML report interactive.
+
 ## 2025-02-25
 
 ### Added


### PR DESCRIPTION
Using purely CSS, this patch adds a checkbox at the top of the report which, when checked, hides all table rows where the severity is "none".

(It may not be entirely aesthetically pleasing, but it's functional.)